### PR TITLE
allow paths without leading /, prepend if required (if host isn't empty)

### DIFF
--- a/src/test/java/at/molindo/utils/tools/UrlBuilderTest.java
+++ b/src/test/java/at/molindo/utils/tools/UrlBuilderTest.java
@@ -19,6 +19,7 @@ package at.molindo.utils.tools;
 import static org.junit.Assert.assertEquals;
 
 import java.net.MalformedURLException;
+import java.net.URL;
 
 import org.junit.Test;
 
@@ -77,5 +78,13 @@ public class UrlBuilderTest {
 		assertEquals(host + "/foo/bar?a=b", b.clone().resolve("?a=b").toUrlString());
 		assertEquals(host + "/foo/qux?a=b", b.clone().resolve("qux?a=b").toUrlString());
 		assertEquals("http://example.org/", b.clone().resolve("http://example.org:80").toUrlString());
+	}
+
+	@Test
+	public void jar() throws MalformedURLException {
+		UrlBuilder b = new UrlBuilder(new URL("jar:file:/some/dir/some.jar!/META-INF/resources/webjars/icon.png"));
+		assertEquals("jar", b.getProtocol());
+		assertEquals("", b.getHost());
+		assertEquals("file:/some/dir/some.jar!/META-INF/resources/webjars/icon.png", b.getPath());
 	}
 }


### PR DESCRIPTION
fixed UrlBuilder according to RFC:

> When authority is present, the path must either be empty or begin with a slash ("/")

from [RFC3986: 3. Syntax Components](https://tools.ietf.org/html/rfc3986#section-3)
