### PR TITLE
added methods to use custom URLCoder to encode params

### DIFF
--- a/src/main/java/at/molindo/utils/tools/UrlBuilder.java
+++ b/src/main/java/at/molindo/utils/tools/UrlBuilder.java
@@ -289,8 +289,20 @@ public class UrlBuilder implements Serializable, Cloneable {
 		return this;
 	}
 
+	public UrlBuilder addParams(URLCoder coder, LinkedHashMap<String, List<String>> params) {
+		for (Map.Entry<String, List<String>> e : params.entrySet()) {
+			addParams(coder, e.getKey(), e.getValue());
+		}
+		return this;
+	}
+
 	public UrlBuilder setParam(String key, String value) {
 		setParams(key, value);
+		return this;
+	}
+
+	public UrlBuilder setParam(URLCoder coder, String key, String value) {
+		setParams(coder, key, value);
 		return this;
 	}
 
@@ -299,13 +311,23 @@ public class UrlBuilder implements Serializable, Cloneable {
 		return this;
 	}
 
+	public UrlBuilder setParams(URLCoder coder, String key, String... values) {
+		setParams(key, Arrays.asList(values));
+		return this;
+	}
+
 	public UrlBuilder setParams(String key, List<String> values) {
+		setParams(URLCoder.QUERY_PARAM, key, values);
+		return this;
+	}
+
+	public UrlBuilder setParams(URLCoder coder, String key, List<String> values) {
 		key = normalizeKey(key);
 		LinkedHashMap<String, List<String>> params = params();
 		if (values == null || values.size() == 0) {
 			params.remove(key);
 		} else {
-			params.put(key, encodeAll(URLCoder.QUERY_PARAM, values));
+			params.put(key, encodeAll(coder, values));
 		}
 
 		return this;
@@ -316,19 +338,34 @@ public class UrlBuilder implements Serializable, Cloneable {
 		return this;
 	}
 
+	public UrlBuilder addParam(URLCoder coder, String key, String value) {
+		addParams(coder, key, value);
+		return this;
+	}
+
+	public UrlBuilder addParams(URLCoder coder, String key, String... values) {
+		addParams(coder, key, Arrays.asList(values));
+		return this;
+	}
+
 	public UrlBuilder addParams(String key, String... values) {
 		addParams(key, Arrays.asList(values));
 		return this;
 	}
 
 	public UrlBuilder addParams(String key, List<String> values) {
+		addParams(URLCoder.QUERY_PARAM, key, values);
+		return this;
+	}
+
+	public UrlBuilder addParams(URLCoder coder, String key, List<String> values) {
 		key = normalizeKey(key);
 		LinkedHashMap<String, List<String>> params = params();
 		List<String> current = params.get(key);
 		if (current == null) {
-			params.put(key, encodeAll(URLCoder.QUERY_PARAM, values));
+			params.put(key, encodeAll(coder, values));
 		} else {
-			current.addAll(encodeAll(URLCoder.QUERY_PARAM, values));
+			current.addAll(encodeAll(coder, values));
 		}
 		return this;
 	}

--- a/src/test/java/at/molindo/utils/tools/UrlBuilderTest.java
+++ b/src/test/java/at/molindo/utils/tools/UrlBuilderTest.java
@@ -17,6 +17,7 @@
 package at.molindo.utils.tools;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -35,7 +36,7 @@ public class UrlBuilderTest {
 	@Test
 	public void url() throws MalformedURLException {
 		String[] urls = { "http://www.google.com/#q=url", "ftp://foo:bar@example.org/files",
-				"https://example.org/?foo=bar&baz=" };
+		"https://example.org/?foo=bar&baz=" };
 		for (String url : urls) {
 			assertEquals(url, UrlBuilder.parse(url).toString());
 		}
@@ -90,6 +91,29 @@ public class UrlBuilderTest {
 
 		assertEquals(urlString, b.toUrlString());
 
+	}
+
+	@Test
+	public void customEncoder() throws MalformedURLException {
+		final String urlString = "http://www.local.setlist.fm:8082/search";
+		final String paramKey = "query";
+		final String paramValue = "frank+turner";
+
+		final String expected = urlString + "?" + paramKey + "=" + paramValue;
+
+		{
+			UrlBuilder defaultEncoder = new UrlBuilder(new URL(urlString));
+			defaultEncoder.addParam(paramKey, paramValue);
+			// plus sign encoded
+			assertNotEquals(expected, defaultEncoder.toUrlString());
+		}
+
+		{
+			UrlBuilder defaultEncoder = new UrlBuilder(new URL(urlString));
+			defaultEncoder.addParam(URLCoder.QUERY, paramKey, paramValue);
+			// plus sign not encoded
+			assertEquals(expected, defaultEncoder.toUrlString());
+		}
 	}
 
 }


### PR DESCRIPTION
need to use custom encoder in order to get urls like http://www.setlist.fm/search?query=frank+turner from UrlBuilder
